### PR TITLE
.hwh file parse code added. Now AXI offsets are extracted from .hwh

### DIFF
--- a/sw/arm/jupyter_notebooks/performance_estimation.ipynb
+++ b/sw/arm/jupyter_notebooks/performance_estimation.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "# Init the performance counters\n",
-    "perfc = PerfCounters()"
+    "perfc = PerfCounters(x_heep)"
    ]
   },
   {

--- a/sw/arm/jupyter_notebooks/virtual_ddr.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_ddr.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "# Initialize DDR memory with desired MB size\n",
-    "ddr = DDR(10)"
+    "ddr = DDR(x_heep, 10)"
    ]
   },
   {
@@ -105,6 +105,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/sw/arm/jupyter_notebooks/virtual_flash_read.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_flash_read.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "# Init the Flash\n",
-    "flash = Flash()"
+    "flash = Flash(x_heep)"
    ]
   },
   {
@@ -144,6 +144,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/sw/arm/jupyter_notebooks/virtual_flash_write.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_flash_write.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "# Init the Flash\n",
-    "flash = Flash()"
+    "flash = Flash(x_heep)"
    ]
   },
   {
@@ -144,6 +144,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/sw/arm/jupyter_notebooks/virtual_gpio_read.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_gpio_read.ipynb
@@ -78,6 +78,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/sw/arm/jupyter_notebooks/virtual_obi_read.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_obi_read.ipynb
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "# Init the OBI memory\n",
-    "obi = OBI()"
+    "obi = OBI(x_heep)"
    ]
   },
   {

--- a/sw/arm/jupyter_notebooks/virtual_obi_write.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_obi_write.ipynb
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "# Init the OBI memory\n",
-    "obi = OBI()"
+    "obi = OBI(x_heep)"
    ]
   },
   {
@@ -113,6 +113,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/sw/arm/jupyter_notebooks/virtual_r_obi_read_and_write.ipynb
+++ b/sw/arm/jupyter_notebooks/virtual_r_obi_read_and_write.ipynb
@@ -35,7 +35,7 @@
     "# Second bank = 1\n",
     "# Third bank  = 2\n",
     "# Fourth bank = 3\n",
-    "robi = rOBI(2)"
+    "robi = rOBI(x_heep, 2)"
    ]
   },
   {

--- a/sw/arm/sdk/x_heep_api.py
+++ b/sw/arm/sdk/x_heep_api.py
@@ -11,13 +11,12 @@ from pynq import PL
 
 import x_heep_thread as xht
 from x_heep_gpio import *
+from x_heep_peripheral import get_address_map
 
 import os
 import subprocess
 import serial
 import time
-
-FLASH_AXI_ADDRESS_ADDER_OFFSET      = 0x44A00000
 
 class x_heep(Overlay):
 
@@ -25,6 +24,10 @@ class x_heep(Overlay):
         # Load bitstream
         PL.reset()
         super().__init__(bitstream, **kwargs)
+        
+        # Parse AXI addresses of the peripherals
+        self.address_map = get_address_map(bitstream)
+        
         self.uart_data = []
         self.release_reset()
         self.release_execute_from_flash()
@@ -101,6 +104,7 @@ class x_heep(Overlay):
         flash = allocate(shape=(32768,))
 
         # Write Flash base address to AXI address adder
+        FLASH_AXI_ADDRESS_ADDER_OFFSET = self.address_map["AXI_S_FLASH"]
         axi_address_adder = MMIO(FLASH_AXI_ADDRESS_ADDER_OFFSET, 0x4)
         axi_address_adder.write(0x0, flash.physical_address)
 

--- a/sw/arm/sdk/x_heep_ddr.py
+++ b/sw/arm/sdk/x_heep_ddr.py
@@ -8,15 +8,14 @@
 from pynq import MMIO
 from pynq import allocate
 
-OBI_AXI_ADDRESS_ADDER_OFFSET = 0x43C10000
-
 class DDR():
-    def __init__(self, mem_size):
+    def __init__(self, x_heep, mem_size):
         # Allocate DDR memory
         # Default DDR dtype is 32 bit unsigned, which is of size 4B.
         self.ddr = allocate(shape=(int(1048576*mem_size/4),))
         # Write DDR memory base address to AXI address adder
-        axi_address_adder = MMIO(OBI_AXI_ADDRESS_ADDER_OFFSET, 0x4)
+        self.OBI_AXI_ADDRESS_ADDER_OFFSET = x_heep.address_map["AXI_S_OBI"]
+        axi_address_adder = MMIO(self.OBI_AXI_ADDRESS_ADDER_OFFSET, 0x4)
         axi_address_adder.write(0x0, self.ddr.physical_address)
         # Reset DDR memory
         self.ddr[:] = 0

--- a/sw/arm/sdk/x_heep_flash.py
+++ b/sw/arm/sdk/x_heep_flash.py
@@ -8,14 +8,13 @@
 from pynq import MMIO
 from pynq import allocate
 
-FLASH_AXI_ADDRESS_ADDER_OFFSET     = 0x43C00000
-
 class Flash():
-    def __init__(self):
+    def __init__(self, x_heep):
         # Allocate Flash
         self.flash = allocate(shape=(32768,))
         # Write Flash base address to AXI address adder
-        axi_address_adder = MMIO(FLASH_AXI_ADDRESS_ADDER_OFFSET, 0x4)
+        self.FLASH_AXI_ADDRESS_ADDER_OFFSET = x_heep.address_map["AXI_S_FLASH"]
+        axi_address_adder = MMIO(self.FLASH_AXI_ADDRESS_ADDER_OFFSET, 0x4)
         axi_address_adder.write(0x0, self.flash.physical_address)
         # Reset Flash
         self.flash[:] = 0

--- a/sw/arm/sdk/x_heep_perf_counters.py
+++ b/sw/arm/sdk/x_heep_perf_counters.py
@@ -8,14 +8,13 @@ from pynq import MMIO
 from pynq import allocate
 import csv
 
-PERFORMANCE_COUNTERS_OFFSET = 0x43C20000
-# PERFORMANCE_COUNTERS_OFFSET = 0x44A10000 # Uncomment to use the vADC
-
 class PerfCounters():
-    def __init__(self):
+    def __init__(self, x_heep):
+        # Get performance counter address
+        self.PERFORMANCE_COUNTERS_OFFSET = x_heep.address_map["AXI_S_PERF_CNT"]
 
         # Map performance counters
-        self.pc = MMIO(PERFORMANCE_COUNTERS_OFFSET, 256)
+        self.pc = MMIO(self.PERFORMANCE_COUNTERS_OFFSET, 256)
 
         # Reset performance counters
         self.pc.write(0x0, 0x1)

--- a/sw/arm/sdk/x_heep_peripheral.py
+++ b/sw/arm/sdk/x_heep_peripheral.py
@@ -1,0 +1,27 @@
+import xml.dom.minidom
+
+
+def get_address_map(bitstream="/home/xilinx/x-heep-femu-sdk/hw/x_heep.bit"):
+    
+    # Get the corresponding .hwh pair to the .bit file
+    hwh_dir = bitstream[:-4] + ".hwh"
+    
+    # Read the .hwh file to parse
+    hwh_file = xml.dom.minidom.parse(hwh_dir)
+
+    try:
+        # Get the node with MEMORYMAP, there are many on those, but they are all the same
+        memory_map = hwh_file.getElementsByTagName("MEMORYMAP")[0] #same addresses are iteratively existent
+
+        # Get each element
+        memory_ranges = memory_map.getElementsByTagName("MEMRANGE")
+
+        address_offset_map = dict()
+
+        for a in range(len(memory_ranges)):
+            address_offset_map[memory_ranges[a].getAttribute("INSTANCE")] = int(memory_ranges[a].getAttribute("BASEVALUE"), 16)
+
+        return address_offset_map
+    
+    except:
+        print("No AXI MMIO found!")


### PR DESCRIPTION
## X_HEEP_PERIPHERALS.py

All the AXI offsets are extracted automatically now by parsing the .hwh file. Also, all the peripheral modules (OBI, DDR) now require inputting x_heep class, since all the AXI addresses are kept locally in x_heep class as attributes (This is needed to synchronize module initializations, x_heep() and OBI(), etc.)

### !!VADC example is yet to be tested.!!

@simone-machetti @JuanSapriza 